### PR TITLE
add onAfterEvent set of listeners

### DIFF
--- a/src/event.ts
+++ b/src/event.ts
@@ -29,6 +29,7 @@ export interface GraphEventSource {
 
 export class GraphEventsStream extends Graph implements GraphEventSource {
   private listeners = new Set<GraphEventListener>();
+  private afterListeners = new Set<GraphEventListener>();
 
   private pushEvent(
     type: GraphEventType,
@@ -36,13 +37,22 @@ export class GraphEventsStream extends Graph implements GraphEventSource {
     emitter: GraphEventSource
   ) {
     console.log(`pushing event: ${type}, key: ${key}, emitter: ${emitter}`);
+
     this.listeners.forEach(listener => {
+      listener(type, key, emitter);
+    });
+
+    this.afterListeners.forEach(listener => {
       listener(type, key, emitter);
     });
   }
 
   addListener(listener: GraphEventListener) {
     this.listeners.add(listener);
+  }
+
+  addAfterListener(listener: GraphEventListener) {
+    this.afterListeners.add(listener);
   }
 
   addNode(value?: any, emitter?: GraphEventSource) {

--- a/src/systems/system.ts
+++ b/src/systems/system.ts
@@ -24,6 +24,8 @@ export abstract class GraphSystem {
 
   abstract onEvent(type: GraphEventType, key: string): void;
 
+  onAfterEvent(type: GraphEventType, key: string): void {}
+
   restart(graph: GraphEventsStream) {
     this.stop();
     this.graph = new GraphEventsSharedDispatchListener(this, graph);
@@ -52,6 +54,7 @@ class GraphEventsSharedDispatchListener implements Graph {
     this.nodes = source.nodes;
     this.edges = source.edges;
     source.addListener(this.onEvent.bind(this));
+    source.addAfterListener(this.onAfterEvent.bind(this));
   }
 
   private onEvent(
@@ -61,6 +64,16 @@ class GraphEventsSharedDispatchListener implements Graph {
   ): void {
     if (emitter !== this) {
       this.sink.onEvent(type, key);
+    }
+  }
+
+  private onAfterEvent(
+    type: GraphEventType,
+    key: string,
+    emitter: GraphEventSource
+  ): void {
+    if (emitter !== this) {
+      this.sink.onAfterEvent(type, key);
     }
   }
 
@@ -86,6 +99,10 @@ class GraphEventsSharedDispatchListener implements Graph {
 
   addListener(listener: GraphEventListener): void {
     this.source.addListener(listener);
+  }
+
+  addAfterListener(listener: GraphEventListener): void {
+    this.source.addAfterListener(listener);
   }
 
   getNodeByKey(key: string): GraphNode | undefined {


### PR DESCRIPTION
They are called after all systems' `onEvent` listeners are called. Which is convenient for systems that depend on other systems.

This, however, has a major flaw. Let's say system A needs system B to be done processing an event before it can process it. The current implementation will only work if the event emitter isn't system B, because when system B is the emitter, it's onEvent is not called. System B handles the event after firing it, and thus after all the `onEvent` and `onAfterEvent` methods are called. See the visual system's addNode/addEdge for an example of this behavior.